### PR TITLE
Enable to use slack Events API

### DIFF
--- a/src/main/scala/slack/models/Events.scala
+++ b/src/main/scala/slack/models/Events.scala
@@ -5,6 +5,23 @@ import play.api.libs.json._
 // TODO: Revisit all event objects (some are partial? - specifically channel)
 sealed trait SlackEvent
 
+case class SlackEventStructure (
+  token: String,
+  team_id: String,
+  api_app_id: String,
+  event: SlackEvent,
+  `type`: String,
+  authed_teams: List[String],
+  event_id: String,
+  event_time: Long
+)
+
+case class EventServerChallenge (
+  token: String,
+  challenge: String,
+  `type`: String
+)
+
 case class Hello (
   `type`: String
 ) extends SlackEvent

--- a/src/main/scala/slack/models/Events.scala
+++ b/src/main/scala/slack/models/Events.scala
@@ -11,7 +11,8 @@ case class SlackEventStructure (
   api_app_id: String,
   event: SlackEvent,
   `type`: String,
-  authed_teams: List[String],
+  authed_teams: Option[List[String]],
+  authed_users: Option[List[String]],
   event_id: String,
   event_time: Long
 )

--- a/src/main/scala/slack/models/package.scala
+++ b/src/main/scala/slack/models/package.scala
@@ -361,4 +361,6 @@ package object models {
       }
     }
   }
+  implicit val slackEventStructureFmt = Json.format[SlackEventStructure]
+  implicit val eventServerChallengeFmt = Json.format[EventServerChallenge]
 }


### PR DESCRIPTION
Hey, I am using this client in combination with the Events API.

However, in order to do so, the modeled events in `Events.scala` have to be wrapped by event type structure of slack (see https://api.slack.com/events-api#event_type_structure).

Furthermore, an server challenge is sent to the url that one provides when subscribing for slack events (see https://api.slack.com/events/url_verification). Therefore, this event has to be modeled.

This PR enables using the defined events of this repo with slack Events API.

I am already using this for few events.

Kind regards