### PR TITLE
make slack url configurable - address Issue #67

### DIFF
--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -3,27 +3,29 @@ package slack.api
 import slack.models._
 
 import java.io.File
+
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.Uri
 import play.api.libs.json._
+import slack.api.SlackApiClient.defaultSlackApiBaseUri
 
 object BlockingSlackApiClient {
 
-  def apply(token: String, duration: FiniteDuration = 5.seconds): BlockingSlackApiClient = {
-    new BlockingSlackApiClient(token, duration)
+  def apply(token: String, slackApiBaseUri:Uri = SlackApiClient.defaultSlackApiBaseUri, duration: FiniteDuration = 5.seconds): BlockingSlackApiClient = {
+    new BlockingSlackApiClient(token, slackApiBaseUri, duration)
   }
 
   def exchangeOauthForToken(clientId: String, clientSecret: String, code: String, redirectUri: Option[String] = None,
-      duration: FiniteDuration = 5.seconds)(implicit system: ActorSystem): AccessToken = {
-    Await.result(SlackApiClient.exchangeOauthForToken(clientId, clientSecret, code, redirectUri), duration)
+      duration: FiniteDuration = 5.seconds, slackApiBaseUri:Uri = defaultSlackApiBaseUri)(implicit system: ActorSystem): AccessToken = {
+    Await.result(SlackApiClient.exchangeOauthForToken(clientId, clientSecret, code, redirectUri, slackApiBaseUri), duration)
   }
 }
 
-class BlockingSlackApiClient(token: String, duration: FiniteDuration = 5.seconds) {
-  val client = new SlackApiClient(token)
-
+class BlockingSlackApiClient private(token: String, slackApiBaseUri:Uri, duration: FiniteDuration) {
+  val client = SlackApiClient(token, slackApiBaseUri)
 
   /**************************/
   /***   Test Endpoints   ***/

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -27,7 +27,7 @@ object SlackApiClient {
   private[api] implicit val fileInfoFmt = Json.format[FileInfo]
   private[api] implicit val reactionsResponseFmt = Json.format[ReactionsResponse]
 
-  val defaultSlackApiBaseUri = Uri(s"https://slack.com/api/")
+  val defaultSlackApiBaseUri = Uri("https://slack.com/api/")
 
   /* TEMPORARY WORKAROUND - UrlEncode '?' in query string parameters */
   val charClassesClass = Class.forName("akka.http.impl.model.parser.CharacterClasses$")

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -27,7 +27,7 @@ object SlackApiClient {
   private[api] implicit val fileInfoFmt = Json.format[FileInfo]
   private[api] implicit val reactionsResponseFmt = Json.format[ReactionsResponse]
 
-  private val apiBaseRequest = HttpRequest(uri = Uri(s"https://slack.com/api/"))
+  val defaultSlackApiBaseUri = Uri(s"https://slack.com/api/")
 
   /* TEMPORARY WORKAROUND - UrlEncode '?' in query string parameters */
   val charClassesClass = Class.forName("akka.http.impl.model.parser.CharacterClasses$")
@@ -39,18 +39,18 @@ object SlackApiClient {
   charPredicateField.set(charClassesObject, updatedCharPredicate)
   /* END TEMPORARY WORKAROUND */
 
-  def apply(token: String): SlackApiClient = {
-    new SlackApiClient(token)
+  def apply(token: String, slackApiBaseUri:Uri = defaultSlackApiBaseUri): SlackApiClient = {
+    new SlackApiClient(token, slackApiBaseUri)
   }
 
-  def exchangeOauthForToken(clientId: String, clientSecret: String, code: String, redirectUri: Option[String] = None)(implicit system: ActorSystem): Future[AccessToken] = {
+  def exchangeOauthForToken(clientId: String, clientSecret: String, code: String, redirectUri: Option[String] = None, slackApiBaseUri:Uri = defaultSlackApiBaseUri)(implicit system: ActorSystem): Future[AccessToken] = {
     val params = Seq (
       "client_id" -> clientId,
       "client_secret" -> clientSecret,
       "code" -> code,
       "redirect_uri" -> redirectUri
     )
-    val res = makeApiRequest(addQueryParams(addSegment(apiBaseRequest, "oauth.access"), cleanParams(params)))
+    val res = makeApiRequest(addQueryParams(addSegment(HttpRequest(uri = slackApiBaseUri), "oauth.access"), cleanParams(params)))
     res.map(_.as[AccessToken])(system.dispatcher)
   }
 
@@ -100,7 +100,9 @@ object SlackApiClient {
 
 import slack.api.SlackApiClient._
 
-class SlackApiClient(token: String) {
+class SlackApiClient private(token: String, slackApiBaseUri:Uri) {
+
+  private val apiBaseRequest = HttpRequest(uri = slackApiBaseUri)
 
   private val apiBaseWithTokenRequest = apiBaseRequest.withUri(apiBaseRequest.uri.withQuery(
                                                           Uri.Query((apiBaseRequest.uri.query() :+ ("token" -> token)): _*)))


### PR DESCRIPTION
Now SlackApiClient/BlockingSlackApiClient/SlackRtmClient accept an optional slackApiBaseUri. If it is not provided then `SlackApiClient.defaultSlackApiBaseUri` is used which is `https://slack.com/api/`
`SlackApiClient` and `BlockingSlackApiClient` now can be easily tested with [wiremock](http://wiremock.org/) since they are just simple HTTP calls.
`SlackRtmClient` needs a websocket server mocking Slack RTM api. It is still missing but one step closer.