### PR TITLE
Add support for https://api.slack.com/methods/users.lookupByEmail

### DIFF
--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -427,6 +427,10 @@ class BlockingSlackApiClient private (token: String, slackApiBaseUri: Uri, durat
     resolve(client.setUserPresence(presence))
   }
 
+  def lookupUserByEmail(emailId: String)(implicit system: ActorSystem): User = {
+    resolve(client.lookupUserByEmail(emailId))
+  }
+
   private def resolve[T](res: Future[T]): T = {
     Await.result(res, duration)
   }

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -719,6 +719,11 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
     extract[Boolean](res, "ok")
   }
 
+  def lookupUserByEmail(emailId: String)(implicit system: ActorSystem): Future[User] = {
+    val res = makeApiMethodRequest("users.lookupByEmail", "email" -> emailId)
+    extract[User](res, "user")
+  }
+
   /*****************************/
   /****  Private Functions  ****/
   /*****************************/


### PR DESCRIPTION
Not sure if tests can be added here since the existing methods don't have them 