### PR TITLE
Fix Content-Type to use correct charset

### DIFF
--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -7,7 +7,6 @@ import scala.concurrent.duration._
 import scala.concurrent.Future
 
 import akka.actor.ActorSystem
-import akka.http.javadsl.model.headers.ContentType
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Source
 import akka.http.scaladsl.Http
@@ -798,8 +797,8 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
   private def makeApiJsonRequest(apiMethod: String, json: JsValue)(implicit system: ActorSystem): Future[JsValue] = {
     val req = addSegment(apiBaseRequest, apiMethod)
       .withMethod(HttpMethods.POST)
-      .withHeaders(ContentType.create(ContentTypes.`application/json`), Authorization(OAuth2BearerToken(token)))
-      .withEntity(json.toString())
+      .withHeaders(Authorization(OAuth2BearerToken(token)))
+      .withEntity(ContentTypes.`application/json`, json.toString())
     makeApiRequest(req)
   }
 }


### PR DESCRIPTION
The Slack API `chat.postMessage` requires the content type to be `Content-type: application/json; charset=utf-8`.  This should be the default when setting the content type using the Scala DSL `withEntity(ContentTypes.`application/json`, entity)`.  The [Akka HTTP docs](https://doc.akka.io/docs/akka-http/current/common/http-model.html#http-headers) also note that Content Type should not be included as an explicit header. 

This PR fixes this scenario by removing the Java DSL explicit Content Type header and replacing it with the Scala DSL method of adding it to the entity instead.

fixes #108 