### PR TITLE
Add proxy support

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,5 +4,6 @@
 - git commit, git push
 - git tag
 - make sure `~/.gnupg/gpg.conf` lists the proper key as the default one (check with `gpg --list-key`)
+- `export GPG_TTY=$(tty)` (Mac only)
 - `sbt +publishSigned`
 - In Sonatype Close the staging repository, and Release it.

--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -4,7 +4,6 @@ import java.io.File
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.settings.ConnectionPoolSettings
 import play.api.libs.json._
 import slack.api.SlackApiClient.defaultSlackApiBaseUri
 import slack.models._
@@ -16,7 +15,7 @@ object BlockingSlackApiClient {
 
   def apply(token: String,
             slackApiBaseUri: Uri = SlackApiClient.defaultSlackApiBaseUri,
-            duration: FiniteDuration = 5.seconds)(implicit system: ActorSystem): BlockingSlackApiClient = {
+            duration: FiniteDuration = 5.seconds): BlockingSlackApiClient = {
     new BlockingSlackApiClient(token, slackApiBaseUri, duration)
   }
 
@@ -26,17 +25,16 @@ object BlockingSlackApiClient {
     code: String,
     redirectUri: Option[String] = None,
     duration: FiniteDuration = 5.seconds,
-    slackApiBaseUri: Uri = defaultSlackApiBaseUri,
-    maybeSettings: Option[ConnectionPoolSettings] = None
+    slackApiBaseUri: Uri = defaultSlackApiBaseUri
   )(implicit system: ActorSystem): AccessToken = {
     Await.result(
-      SlackApiClient.exchangeOauthForToken(clientId, clientSecret, code, redirectUri, slackApiBaseUri, maybeSettings),
+      SlackApiClient.exchangeOauthForToken(clientId, clientSecret, code, redirectUri, slackApiBaseUri),
       duration
     )
   }
 }
 
-class BlockingSlackApiClient private (token: String, slackApiBaseUri: Uri, duration: FiniteDuration)(implicit system: ActorSystem) {
+class BlockingSlackApiClient private (token: String, slackApiBaseUri: Uri, duration: FiniteDuration) {
   val client = SlackApiClient(token, slackApiBaseUri)
 
   /**************************/

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -22,7 +22,9 @@ import scala.util.Try
 object SlackApiClient {
 
   private[this] val config   = ConfigFactory.load()
-  private[this] val useProxy = Try(config.getString("slack-scala-client.http.useproxy")).fold(_ => false, _.toBoolean)
+  private[this] val useProxy: Boolean = Try(config.getString("slack-scala-client.http.useproxy"))
+    .map(_.toBoolean)
+    .recover{case _:Exception => false}.get
 
   private[this] val maybeSettings: Option[ConnectionPoolSettings] = if (useProxy) {
     val proxyHost = config.getString("slack-scala-client.http.proxyHost")

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -1,7 +1,6 @@
 package slack.api
 
 import java.io.File
-import java.lang.reflect.{Field, Modifier}
 import java.net.InetSocketAddress
 
 import akka.actor.ActorSystem
@@ -19,17 +18,17 @@ import slack.models._
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 
 object SlackApiClient extends StrictLogging {
 
   private[this] val config   = ConfigFactory.load()
-  private[this] val useProxy = Try(config.getString("akka.http.client.useproxy")).fold(_ => false, _.toBoolean)
+  private[this] val useProxy = Try(config.getString("slack-scala-client.http.useproxy")).fold(_ => false, _.toBoolean)
 
   private[this] val maybeSettings: Option[ConnectionPoolSettings] = if (useProxy) {
-    val proxyHost = config.getString("akka.http.client.proxyHost")
-    val proxyPort = config.getString("akka.http.client.proxyPort").toInt
+    val proxyHost = config.getString("slack-scala-client.http.proxyHost")
+    val proxyPort = config.getString("slack-scala-client.http.proxyPort").toInt
 
     val httpsProxyTransport = ClientTransport.httpsProxy(InetSocketAddress.createUnresolved(proxyHost, proxyPort))
 

--- a/src/main/scala/slack/rtm/WebSocketClientActor.scala
+++ b/src/main/scala/slack/rtm/WebSocketClientActor.scala
@@ -11,7 +11,7 @@ import akka.http.scaladsl.{ClientTransport, Http}
 import akka.stream.scaladsl._
 import akka.stream.{ActorMaterializer, OverflowStrategy}
 import com.typesafe.config.ConfigFactory
-
+import slack.rtm.WebSocketClientActor._
 import scala.concurrent.Future
 import scala.util.{Failure, Success, Try}
 
@@ -49,8 +49,6 @@ private[rtm] object WebSocketClientActor {
     arf.actorOf(Props(new WebSocketClientActor(url)))
   }
 }
-
-import slack.rtm.WebSocketClientActor._
 
 private[rtm] class WebSocketClientActor(url: String) extends Actor with ActorLogging {
   implicit val ec = context.dispatcher

--- a/src/main/scala/slack/rtm/WebSocketClientActor.scala
+++ b/src/main/scala/slack/rtm/WebSocketClientActor.scala
@@ -29,11 +29,11 @@ private[rtm] object WebSocketClientActor {
   case object WebSocketDisconnected
 
   private[this] val config   = ConfigFactory.load()
-  private[this] val useProxy = Try(config.getString("akka.http.client.useproxy")).fold(_ => false, _.toBoolean)
+  private[this] val useProxy = Try(config.getString("slack-scala-client.http.useproxy")).fold(_ => false, _.toBoolean)
 
   private[WebSocketClientActor] val maybeSettings: Option[ClientConnectionSettings] = if (useProxy) {
-    val proxyHost = config.getString("akka.http.client.proxyHost")
-    val proxyPort = config.getString("akka.http.client.proxyPort").toInt
+    val proxyHost = config.getString("slack-scala-client.http.proxyHost")
+    val proxyPort = config.getString("slack-scala-client.http.proxyPort").toInt
 
     val httpsProxyTransport = ClientTransport.httpsProxy(InetSocketAddress.createUnresolved(proxyHost, proxyPort))
 

--- a/src/main/scala/slack/rtm/WebSocketClientActor.scala
+++ b/src/main/scala/slack/rtm/WebSocketClientActor.scala
@@ -29,7 +29,9 @@ private[rtm] object WebSocketClientActor {
   case object WebSocketDisconnected
 
   private[this] val config   = ConfigFactory.load()
-  private[this] val useProxy = Try(config.getString("slack-scala-client.http.useproxy")).fold(_ => false, _.toBoolean)
+  private[this] val useProxy: Boolean = Try(config.getString("slack-scala-client.http.useproxy"))
+    .map(_.toBoolean)
+    .recover{case _:Exception => false}.get
 
   private[WebSocketClientActor] val maybeSettings: Option[ClientConnectionSettings] = if (useProxy) {
     val proxyHost = config.getString("slack-scala-client.http.proxyHost")

--- a/src/test/resources/application.conf.template
+++ b/src/test/resources/application.conf.template
@@ -1,3 +1,6 @@
+slack-scala-client.http.useproxy = false
+slack-scala-client.http.proxyHost = proxyhost
+slack-scala-client.http.proxyPort = 8080
 test {
   channel="<your channel id here>"
   apiKey="<your API Key here>"

--- a/src/test/resources/travis.application.conf
+++ b/src/test/resources/travis.application.conf
@@ -1,3 +1,6 @@
+slack-scala-client.http.useproxy = false
+slack-scala-client.http.proxyHost = proxyhost
+slack-scala-client.http.proxyPort = 8080
 test {
   channel = "CE5MJ814M" # #travis-ci
   userId = "UE4P9JFHN" # goledzki_slackscalaclient


### PR DESCRIPTION
Added optional support for using proxy.
Default is not to use proxy, most changes are in private functions while public functions get defaults and keep current logic of no proxy and code changes are needed.
Instead of just using implicit system in each api function - I added an implicit system to clients generation to get the needed config in there.