### PR TITLE
Skipping tests if credentials don't exist

### DIFF
--- a/src/test/scala/slack/Credentials.scala
+++ b/src/test/scala/slack/Credentials.scala
@@ -2,11 +2,13 @@ package slack
 
 import akka.actor.ActorSystem
 
+import scala.util.Try
+
 trait Credentials {
 
   implicit val system = ActorSystem("slack")
-  val user = system.settings.config.getString("test.userId")
-  val token = sys.env.getOrElse("SLACK_API", system.settings.config.getString("test.apiKey"))
+  val user: Option[String] = Try(system.settings.config.getString("test.userId")).toOption
+  val token: Option[String] = Try(sys.env.getOrElse("SLACK_API", system.settings.config.getString("test.apiKey"))).toOption
   val rtmToken = token
 
 }

--- a/src/test/scala/slack/SlackApiClientTest.scala
+++ b/src/test/scala/slack/SlackApiClientTest.scala
@@ -10,32 +10,36 @@ import scala.concurrent.duration._
 
 class SlackApiClientTest extends FunSuite with Credentials {
 
-  val apiClient = SlackApiClient(token)
-  val channel = system.settings.config.getString("test.channel")
+  (user, token) match {
+    case (Some(slackUser), Some(slackToken)) =>
+      val apiClient = SlackApiClient(slackToken)
+      val channel = system.settings.config.getString("test.channel")
 
-  test("send attachment with action") {
-    val actionField = Seq(ActionField("accept", "Accept", "button", Some("primary")))
-    val attachment = Attachment(
-      text = Some("Do you want to accept?"),
-      fallback = Some("backup message: code-123456"),
-      callback_id = Some("code-123456"),
-      actions = Some(actionField)
-    )
+      test("send attachment with action") {
+        val actionField = Seq(ActionField("accept", "Accept", "button", Some("primary")))
+        val attachment = Attachment(
+          text = Some("Do you want to accept?"),
+          fallback = Some("backup message: code-123456"),
+          callback_id = Some("code-123456"),
+          actions = Some(actionField)
+        )
 
-    apiClient.listChannels(1).map { channels =>
-      channels.foreach(channel => println(s"${channel.id}|${channel.name}"))
-    }
-    val future = apiClient.postChatMessage(channel, "Request", attachments = Some(Seq(attachment)))
-    val result = Await.result(future, 5.seconds)
+        apiClient.listChannels(1).map { channels =>
+          channels.foreach(channel => println(s"${channel.id}|${channel.name}"))
+        }
+        val future = apiClient.postChatMessage(channel, "Request", attachments = Some(Seq(attachment)))
+        val result = Await.result(future, 5.seconds)
 
-    println(result)
+        println(result)
+      }
+
+      test("send ephemeral with action") {
+        val future = apiClient.postChatEphemeral(channel, "This is an ephemeral", slackUser)
+        val result = Await.result(future, 5.seconds)
+
+        println(result)
+      }
+    case _ =>
+      println("Skipping the test as the API credentials are not available")
   }
-
-  test("send ephemeral with action") {
-    val future = apiClient.postChatEphemeral(channel, "This is an ephemeral", user)
-    val result = Await.result(future, 5.seconds)
-
-    println(result)
-  }
-
 }

--- a/src/test/scala/slack/SlackRtmClientTest.scala
+++ b/src/test/scala/slack/SlackRtmClientTest.scala
@@ -12,43 +12,50 @@ import scala.concurrent.{Await, Promise}
 
 class SlackRtmClientTest extends FunSuite with Matchers with Credentials {
 
-  val channel = system.settings.config.getString("test.channel")
+  rtmToken match {
+    case Some(slackToken) =>
 
-  lazy val rtmClient = {
-    val rtm = SlackRtmClient(rtmToken)
-    assert(rtm.state.self.id != null)
-    rtm
-  }
-  test("rtm typing") {
-    rtmClient.indicateTyping(channel)
-  }
+      val channel = system.settings.config.getString("test.channel")
 
-  test("team domain") {
-    val domain = rtmClient.state.team.domain
-    val name = rtmClient.state.team.name
-    domain should be(system.settings.config.getString("test.team.domain"))
-    name should be(system.settings.config.getString("test.team.name"))
-  }
+      lazy val rtmClient = {
+        val rtm = SlackRtmClient(slackToken)
+        assert(rtm.state.self.id != null)
+        rtm
+      }
+      test("rtm typing") {
+        rtmClient.indicateTyping(channel)
+      }
 
-  test("send message and parse reply") {
-    val latch = new CountDownLatch(1)
-    val promise = Promise[Long]()
-    rtmClient.onEvent {
-      case r: Reply =>
-        assert(r.reply_to.equals(Await.result(promise.future, 2.seconds)))
-        latch.countDown()
-      case e => println("EVENT >>>>> " + e)
-    }
-    val messageIdFuture = rtmClient.sendMessage(channel, "Hi there")
-    promise.completeWith(messageIdFuture)
-    latch.await(5, TimeUnit.SECONDS)
-  }
+      test("team domain") {
+        val domain = rtmClient.state.team.domain
+        val name = rtmClient.state.team.name
+        domain should be(system.settings.config.getString("test.team.domain"))
+        name should be(system.settings.config.getString("test.team.name"))
+      }
 
-  ignore("edit message as bot") {
-    val rtmApi = SlackApiClient(rtmToken)
-    val future = rtmApi.updateChatMessage(channel, "1465891701.000006", "edit-x", asUser = Some(true))
-    val result = Await.result(future, 5.seconds)
-    assert(result.ok.equals(true))
-  }
+      test("send message and parse reply") {
+        val latch = new CountDownLatch(1)
+        val promise = Promise[Long]()
+        rtmClient.onEvent {
+          case r: Reply =>
+            assert(r.reply_to.equals(Await.result(promise.future, 2.seconds)))
+            latch.countDown()
+          case e => println("EVENT >>>>> " + e)
+        }
+        val messageIdFuture = rtmClient.sendMessage(channel, "Hi there")
+        promise.completeWith(messageIdFuture)
+        latch.await(5, TimeUnit.SECONDS)
+      }
 
+      ignore("edit message as bot") {
+        val rtmApi = SlackApiClient(slackToken)
+        val future = rtmApi.updateChatMessage(channel, "1465891701.000006", "edit-x", asUser = Some(true))
+        val result = Await.result(future, 5.seconds)
+        assert(result.ok.equals(true))
+      }
+
+    case _ =>
+      println("Skipping the test as the API credentials are not available")
+
+  }
 }


### PR DESCRIPTION
## Why
Due to / Thanks to the way secrets are handled by Travis CI for *open-source* project like this, we cannot run the integration tests towards real Slack for pull requests. As that would cause the credentials to leak.

## What
So we skip the tests when API credentials are unavailable.
And we continue to run these two tests if they are available - that is:
- either it's a master run in Travis CI
- or someone specifies the credentials manually in their local `src/test/resources/application.conf`

## How
This is kind of lame with this one huge case/match. I haven't found a cleaner way in Scalatest. https://stackoverflow.com/q/32460295/118587 suggests it's doable, but:
- I didn't try the Tags
- the `cancel` or `assume` is not what we need here, as it causes a failure, not skipping of a test