### PR TITLE
Enabling scapegoat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,3 +5,5 @@ lazy val slackScalaClient =
     .settings ( scalacOptions ++= Seq("-unchecked", "-deprecation", "-Xfatal-warnings", "-Xlint", "-feature") )
 
 releasePublishArtifactsAction := PgpKeys.publishSigned.key
+
+scapegoatVersion in ThisBuild := "1.4.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
-addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.9")
+addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.1.0")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,4 @@
-
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.11")
-
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.10")
-
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0")
+addSbtPlugin("com.sksamuel.scapegoat" %% "sbt-scapegoat" % "1.0.9")


### PR DESCRIPTION
Enabling Scapegoat static analysis tool as something you can optionally run with `scapegoat` in `sbt`