### PR TITLE
Removing question-mark encoding workaround.

### DIFF
--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -12,7 +12,6 @@ import akka.stream.scaladsl.Source
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
-import akka.parboiled2.CharPredicate
 import play.api.libs.json._
 
 object SlackApiClient {
@@ -27,16 +26,6 @@ object SlackApiClient {
   private[api] implicit val reactionsResponseFmt = Json.format[ReactionsResponse]
 
   val defaultSlackApiBaseUri = Uri("https://slack.com/api/")
-
-  /* TEMPORARY WORKAROUND - UrlEncode '?' in query string parameters */
-  val charClassesClass = Class.forName("akka.http.impl.model.parser.CharacterClasses$")
-  val charClassesObject = charClassesClass.getField("MODULE$").get(charClassesClass)
-  //  strict-query-char-np
-  val charPredicateField = charClassesObject.getClass.getDeclaredField("strict$minusquery$minuschar$minusnp")
-  charPredicateField.setAccessible(true)
-  val updatedCharPredicate = charPredicateField.get(charClassesObject).asInstanceOf[CharPredicate] -- '?'
-  charPredicateField.set(charClassesObject, updatedCharPredicate)
-  /* END TEMPORARY WORKAROUND */
 
   def apply(token: String, slackApiBaseUri: Uri = defaultSlackApiBaseUri): SlackApiClient = {
     new SlackApiClient(token, slackApiBaseUri)

--- a/src/test/scala/slack/SlackApiClientTest.scala
+++ b/src/test/scala/slack/SlackApiClientTest.scala
@@ -32,7 +32,7 @@ class SlackApiClientTest extends FunSuite with Credentials {
   }
 
   test("send ephemeral with action") {
-    val future = apiClient.postChatEphemeral(channel, "This is an ephemeral", user)
+    val future = apiClient.postChatEphemeral(channel, "This is an ephemeral. How are you?", user)
     val result = Await.result(future, 5.seconds)
 
     println(result)

--- a/src/test/scala/slack/SlackApiClientTest.scala
+++ b/src/test/scala/slack/SlackApiClientTest.scala
@@ -34,7 +34,7 @@ class SlackApiClientTest extends FunSuite with Credentials {
       }
 
       test("send ephemeral with action") {
-        val future = apiClient.postChatEphemeral(channel, "This is an ephemeral. How are you?", user)
+        val future = apiClient.postChatEphemeral(channel, "This is an ephemeral. How are you?", slackUser)
         val result = Await.result(future, 5.seconds)
 
         println(result)


### PR DESCRIPTION
Fixes #113 by removing the question-mark encoding workaround.
Now the tests pass with Scala 2.13 too.
So basically it's a revert of the old workaround added in #60 