### PR TITLE
Fixing warnings

### DIFF
--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -669,7 +669,7 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
       "timestamp" -> timestamp,
       "full" -> full
     )
-    res.map(r => (r \\ "reactions").headOption.map(_.as[Seq[Reaction]]).getOrElse(Seq.empty[Reaction])(system.dispatcher)
+    res.map(r => (r \\ "reactions").headOption.map(_.as[Seq[Reaction]]).getOrElse(Seq.empty[Reaction]))(system.dispatcher)
   }
 
   def getReactionsForMessage(channelId: String, timestamp: String, full: Option[Boolean] = None)(

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -87,7 +87,7 @@ object SlackApiClient {
   }
 
   private def cleanParams(params: Seq[(String, Any)]): Seq[(String, String)] = {
-    var paramList = Seq[(String, String)]()
+    var paramList = Seq.empty[(String, String)]
     params.foreach {
       case (k, Some(v)) => paramList :+= (k -> v.toString)
       case (k, None) => // Nothing - Filter out none
@@ -669,7 +669,7 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
       "timestamp" -> timestamp,
       "full" -> full
     )
-    res.map(r => (r \\ "reactions").headOption.map(_.as[Seq[Reaction]]).getOrElse(Seq[Reaction]()))(system.dispatcher)
+    res.map(r => (r \\ "reactions").headOption.map(_.as[Seq[Reaction]]).getOrElse(Seq.empty[Reaction])(system.dispatcher)
   }
 
   def getReactionsForMessage(channelId: String, timestamp: String, full: Option[Boolean] = None)(

--- a/src/main/scala/slack/rtm/SlackRtmClient.scala
+++ b/src/main/scala/slack/rtm/SlackRtmClient.scala
@@ -173,7 +173,7 @@ private[rtm] class SlackRtmConnectionActor(apiClient: BlockingSlackApiClient, st
     case Terminated(actor) =>
       listeners -= actor
       handleWebSocketDisconnect(actor)
-    case SendPing =>
+    case SendPing() =>
       val nextId = idCounter.getAndIncrement
       val payload = Json.stringify(Json.toJson(Ping(nextId)))
       webSocketClient.get ! SendWSMessage(TextMessage(payload))

--- a/src/main/scala/slack/rtm/WebSocketClientActor.scala
+++ b/src/main/scala/slack/rtm/WebSocketClientActor.scala
@@ -47,9 +47,7 @@ private[rtm] class WebSocketClientActor(url: String) extends Actor with ActorLog
     case m: Message =>
       log.debug("[WebsocketClientActor] Received Message: {}", m)
     case SendWSMessage(m) =>
-      if (outboundMessageQueue.isDefined) {
-        outboundMessageQueue.get.offer(m)
-      }
+      outboundMessageQueue.map(_.offer(m))
     case WebSocketConnectSuccess(queue, closed) =>
       outboundMessageQueue = Some(queue)
       closed.onComplete(_ => self ! WebSocketDisconnected)


### PR DESCRIPTION
Minor refactor fixes based on Scapegoat reports.

One I actually believe is not a refactoring, but a real fix:
```
    case SendPing =>
```
I suspect this didn't work before.