### PR TITLE
Make toStrict timeout configurable

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,1 +1,2 @@
 akka.http.client.parsing.max-content-length=128m
+api.tostrict.timeout=10


### PR DESCRIPTION
The default timeout of 10 seconds for `toStrict` in API requests is not long enough for big organizations which have a very large state. In particular, initializing a `SlackRtmClient` is prone to fail on a `java.util.concurrent.TimeoutException`. This patch tries to make the timeout configurable.