### PR TITLE
Expose unfurl parameters in SlackRtmClient

### DIFF
--- a/src/main/scala/slack/rtm/SlackRtmClient.scala
+++ b/src/main/scala/slack/rtm/SlackRtmClient.scala
@@ -50,8 +50,12 @@ class SlackRtmClient(token: String, slackApiBaseUri: Uri, duration: FiniteDurati
     handler
   }
 
-  def sendMessage(channelId: String, text: String, thread_ts: Option[String] = None): Future[Long] = {
-    (actor ? SendMessage(channelId, text, thread_ts)).mapTo[Long]
+  def sendMessage(channelId: String,
+                  text: String,
+                  thread_ts: Option[String] = None,
+                  unfurl_links: Option[Boolean] = None,
+                  unfurl_media: Option[Boolean] = None): Future[Long] = {
+    (actor ? SendMessage(channelId, text, thread_ts, unfurl_links, unfurl_media)).mapTo[Long]
   }
 
   def editMessage(channelId: String, ts: String, text: String): Unit = {


### PR DESCRIPTION
Expose unfurl option parameters added in https://github.com/slack-scala-client/slack-scala-client/pull/162