### PR TITLE
fix issue with token

### DIFF
--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -211,9 +211,7 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
 
   private val apiBaseRequest = HttpRequest(uri = slackApiBaseUri)
 
-  private val apiBaseWithTokenRequest = apiBaseRequest.withUri(
-    apiBaseRequest.uri.withQuery(Uri.Query((apiBaseRequest.uri.query() :+ ("token" -> token)): _*))
-  )
+  private val apiBaseWithTokenRequest = apiBaseRequest.withHeaders(Authorization(OAuth2BearerToken(token)))
 
   /**************************/
   /***   Test Endpoints   ***/


### PR DESCRIPTION
Tested by creating a test app using the listChannels route. No longer receives `invalid_auth` error. 
Uses same implementation as `makeJsonApiRequest`