### PR TITLE
Deprecate listChannels in favor of listConversations

### DIFF
--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -83,8 +83,13 @@ class BlockingSlackApiClient private (token: String, slackApiBaseUri: Uri, durat
     resolve(client.kickFromChannel(channelId, userId))
   }
 
+  @deprecated("use listConversations", "0.2.18")
   def listChannels(excludeArchived: Boolean = false)(implicit system: ActorSystem): Seq[Channel] = {
-    resolve(client.listChannels(excludeArchived))
+    listConversations(Seq(PublicChannel, PrivateChannel), excludeArchived)
+  }
+
+  def listConversations(channelTypes: Seq[ConversationType] = Seq(PublicChannel), excludeArchived: Boolean = false)(implicit system: ActorSystem): Seq[Channel] = {
+    resolve(client.listConversations(channelTypes, if (excludeArchived) 1 else 0))
   }
 
   def leaveChannel(channelId: String)(implicit system: ActorSystem): Boolean = {

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -275,9 +275,9 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
     extract[Boolean](res, "ok")
   }
 
+  @deprecated("use listConversations", "0.2.18")
   def listChannels(excludeArchived: Boolean = false)(implicit system: ActorSystem): Future[Seq[Channel]] = {
-    val res = makeApiMethodRequest("channels.list", "exclude_archived" -> excludeArchived.toString)
-    extract[Seq[Channel]](res, "channels")
+    listConversations(Seq(PublicChannel, PrivateChannel), if (excludeArchived) 1 else 0)
   }
 
   def listConversations(channelTypes: Seq[ConversationType] = Seq(PublicChannel), excludeArchived: Int = 0)(implicit system: ActorSystem): Future[Seq[Channel]] = {

--- a/src/test/scala/slack/SlackApiClientTest.scala
+++ b/src/test/scala/slack/SlackApiClientTest.scala
@@ -27,7 +27,7 @@ class SlackApiClientTest extends AnyFunSuite with Credentials {
           actions = Some(actionField)
         )
 
-        apiClient.listChannels().map { channels =>
+        apiClient.listConversations().map { channels =>
           channels.foreach(channel => println(s"${channel.id}|${channel.name}"))
         }
         val future = apiClient.postChatMessage(channel, "Request", attachments = Some(Seq(attachment)))


### PR DESCRIPTION
Fixes #175 

As suggested in the issue, this pr changes the implementation of `listChannels` to use `listConversations` under the hood, keeping the original methods, but deprecating them. 