### PR TITLE
Upgrading to akka-http 10.2

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -50,7 +50,7 @@ object Dependencies {
 
   val akkaActor = "com.typesafe.akka" %% "akka-actor" % akkaVersion
   val akkaStream = "com.typesafe.akka" %% "akka-stream" % akkaVersion
-  val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % "10.1.15"
+  val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % "10.2.8"
 
   val playJson = "com.typesafe.play" %% "play-json" % "2.7.4"
 


### PR DESCRIPTION
For no specific reason other than staying up to date.

https://doc.akka.io/docs/akka-http/current/compatibility-guidelines.html says:
> Akka HTTP 10.2.x is (binary) compatible with Akka >= 2.5.32 and Akka >= 2.6.8 and future Akka 2.x versions that are released during the lifetime of Akka HTTP 10.2.x.