### PR TITLE
Dropping support for Scala 2.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Deprecating `listChannels` (#197)
 * Code re-arrangement (#204)
 * Dependency version upgrades
+* Drop support for Scala 2.11 (#201)
 
 0.2.17 (2021-08-17)
 -------------------

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -10,7 +10,7 @@ object BuildSettings {
     organization       := buildOrganization,
     version            := buildVersion,
     scalaVersion       := buildScalaVersion,
-    crossScalaVersions :=  Seq("2.11.12", scalaVersion.value, "2.13.8"),
+    crossScalaVersions :=  Seq(scalaVersion.value, "2.13.8"),
     publishMavenStyle  := true,
     credentials += Credentials(Path.userHome / ".sbt" / ".credentials"),
     publishTo          := {


### PR DESCRIPTION
Fixes #201.

Other than the obvious "let's keep up with the progress" reasons. The trigger was that the latest akka-http doesn't support Scala 2.11