### PR TITLE
Update deprecated im.open and im.close API endpoints

### DIFF
--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -885,7 +885,7 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
   def closeIm(
       channelId: String
   )(implicit system: ActorSystem): Future[Boolean] = {
-    val res = makeApiMethodRequest("im.close", "channel" -> channelId)
+    val res = makeApiMethodRequest("conversations.close", "channel" -> channelId)
     extract[Boolean](res, "ok")
   }
 
@@ -921,7 +921,7 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
   }
 
   def openIm(userId: String)(implicit system: ActorSystem): Future[String] = {
-    val res = makeApiMethodRequest("im.open", "user" -> userId)
+    val res = makeApiMethodRequest("conversations.open", "users" -> userId)
     res.map(r => (r \ "channel" \ "id").as[String])(system.dispatcher)
   }
 


### PR DESCRIPTION
At some point, im.open stopped working, returning an error about the method being deprecated.

Luckily, the new conversation.open/close arguments are very similar.

This PR adds a minor change fixing these two methods (only).

I believe other methods should be migrated as well at some point (history, list, mark), but I have no capacity to implement and test them.

However, .open and .close are tested and work well (refs https://github.com/Firfi/slack-baka/commit/1821d16b8c0f1fe9d276980f271f7b8a2ea56a7a which uses my fork now)