### PR TITLE
Removing mentions of ActorMaterializer

### DIFF
--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -11,7 +11,6 @@ import akka.http.scaladsl.settings.{
   ConnectionPoolSettings
 }
 import akka.http.scaladsl.{ClientTransport, Http}
-import akka.stream.{ActorMaterializer, ActorMaterializerSettings}
 import akka.stream.scaladsl.{RestartSource, Sink, Source}
 import com.typesafe.config.ConfigFactory
 import play.api.libs.json._
@@ -102,7 +101,6 @@ object SlackApiClient {
   private def makeApiRequest(
       request: HttpRequest
   )(implicit system: ActorSystem): Future[Either[RetryAfter, JsValue]] = {
-    implicit val mat = ActorMaterializer()
     implicit val ec = system.dispatcher
     val connectionPoolSettings: ConnectionPoolSettings =
       maybeSettings.getOrElse(ConnectionPoolSettings(system))
@@ -1342,9 +1340,6 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
       field: String,
       initialResults: Seq[T] = Seq.empty[T]
   )(implicit system: ActorSystem, fmt: Format[Seq[T]]): Future[Seq[T]] = {
-    implicit val materializer: ActorMaterializer = ActorMaterializer(
-      ActorMaterializerSettings(system)
-    )
     implicit val ec: ExecutionContext = system.dispatcher
 
     RestartSource

--- a/src/main/scala/slack/rtm/WebSocketClientActor.scala
+++ b/src/main/scala/slack/rtm/WebSocketClientActor.scala
@@ -1,18 +1,17 @@
 package slack.rtm
 
-import java.net.{InetSocketAddress, URI}
-
 import akka.Done
 import akka.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, Props}
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
 import akka.http.scaladsl.settings.ClientConnectionSettings
 import akka.http.scaladsl.{ClientTransport, Http}
+import akka.stream.OverflowStrategy
 import akka.stream.scaladsl._
-import akka.stream.{ActorMaterializer, OverflowStrategy}
 import com.typesafe.config.ConfigFactory
 import slack.rtm.WebSocketClientActor._
 
+import java.net.{InetSocketAddress, URI}
 import scala.concurrent.Future
 import scala.util.{Failure, Success}
 
@@ -52,7 +51,6 @@ private[rtm] object WebSocketClientActor {
 private[rtm] class WebSocketClientActor(url: String) extends Actor with ActorLogging {
   implicit val ec = context.dispatcher
   implicit val system = context.system
-  implicit val materalizer = ActorMaterializer()
 
   val uri = new URI(url)
   var outboundMessageQueue: Option[SourceQueueWithComplete[Message]] = None


### PR DESCRIPTION
In Akka 2.6 (#220) `ActorMaterializer` is deprecated. The warnings given are:
```
 method apply in object ActorMaterializer is deprecated (since 2.6.0): Use the system wide materializer or Materializer.apply(actorContext) with stream attributes or configuration settings to change defaults
[error]     implicit val materializer: ActorMaterializer = ActorMaterializer(
```
TBH, I don't want it is, but following https://stackoverflow.com/a/58768480/118587 I assume it's fine to remove it. Since we already have `ActorSystem` implicit available in these scopes.