### PR TITLE
channel's name to be optional

### DIFF
--- a/models/src/main/scala/slack/models/Channel.scala
+++ b/models/src/main/scala/slack/models/Channel.scala
@@ -3,7 +3,7 @@ package slack.models
 import play.api.libs.json._
 
 case class Channel(id: String,
-                   name: String,
+                   name: Option[String],
                    created: Long,
                    creator: Option[String],
                    is_archived: Option[Boolean],

--- a/src/test/scala/slack/TestJsonMessages.scala
+++ b/src/test/scala/slack/TestJsonMessages.scala
@@ -216,7 +216,7 @@ class TestJsonMessages extends AnyFunSuite with Matchers {
         |"event_ts":"1542211100.033200"}
       """.stripMargin)
     val ev = json.as[ChannelRename]
-    ev.channel.name should be("newname")
+    ev.channel.name should be(Some("newname"))
   }
 
   test("message replied") {


### PR DESCRIPTION
My slackbot has conv with only 2 IM channels, which resulted `listConversations()`  with the following error:

`JsResultException(errors:List(((0)/name,List(JsonValidationError(List(error.path.missing),List()))), ((1)/name,List(JsonValidationError(List(error.path.missing),List())))))`

the channels are practically nameless so in order to fix the json validation error, I just fixed by not expecting a name.

<img width="447" alt="Screenshot 2023-09-09 at 12 08 39" src="https://github.com/slack-scala-client/slack-scala-client/assets/142509022/787105f7-d746-42f3-bae4-7814858847b9">
