### PR TITLE
Migrating to Pekko

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ client.onEvent {
 
 A full list of events can be found in [Events.scala](models/src/main/scala/slack/models/Events.scala). One thing to note is the two above functions return an `ActorRef` which is a handle to the underlying actor running the above handler function. This can be used to terminate the handler by terminating the actor: ```system.stop(handler)```, or unregistering it as a listener: ```client.removeEventListener(handler)```
 
-A Pekka actor can be manually registered as an event listener and all events will be sent to that actor:
+A Pekko actor can be manually registered as an event listener and all events will be sent to that actor:
 
 ```scala
 val actor = system.actorOf(Props[SlackEventHandler])

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ The API clients implement the full Slack API. A full list of the available endpo
 
 ## RTM Client Usage
 
-The real time messaging client is implemented using akka and requires having an implicit `ActorSystem` in scope. Either an `ActorSystem` or `ActorContext` will work:
+The real time messaging client is implemented using Pekko and requires having an implicit `ActorSystem` in scope. Either an `ActorSystem` or `ActorContext` will work:
 
 ```scala
 import slack.rtm.SlackRtmClient
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 
 implicit val system: ActorSystem = ActorSystem("slack")
 ```
@@ -120,7 +120,7 @@ client.onEvent {
 
 A full list of events can be found in [Events.scala](models/src/main/scala/slack/models/Events.scala). One thing to note is the two above functions return an `ActorRef` which is a handle to the underlying actor running the above handler function. This can be used to terminate the handler by terminating the actor: ```system.stop(handler)```, or unregistering it as a listener: ```client.removeEventListener(handler)```
 
-An Akka actor can be manually registered as an event listener and all events will be sent to that actor:
+A Pekka actor can be manually registered as an event listener and all events will be sent to that actor:
 
 ```scala
 val actor = system.actorOf(Props[SlackEventHandler])

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -46,13 +46,13 @@ object BuildSettings {
 }
 
 object Dependencies {
-  val akkaVersion = "2.6.20"
+  val pekkaVersion = "1.0.2"
 
-  val akkaActor = "com.typesafe.akka" %% "akka-actor" % akkaVersion
-  val akkaStream = "com.typesafe.akka" %% "akka-stream" % akkaVersion
-  val akkaHttp = "com.typesafe.akka" %% "akka-http-core" % "10.2.10"
+  val pekkoActor = "org.apache.pekko" %% "pekko-actor" % pekkaVersion
+  val pekkoStream = "org.apache.pekko" %% "pekko-stream" % pekkaVersion
+  val pekkoHttp = "org.apache.pekko" %% "pekko-http-core" % "1.0.1"
 
-  val playJson = "com.typesafe.play" %% "play-json" % "2.10.2"
+  val playJson = "com.typesafe.play" %% "play-json" % "2.10.5"
 
   val scalatest = "org.scalatest" %% "scalatest" % "3.2.17" % Test
 
@@ -60,9 +60,9 @@ object Dependencies {
 
   val scalaJava8Compat = "org.scala-lang.modules" %% "scala-java8-compat" % "1.0.2"
 
-  val akkaDependencies = Seq(akkaHttp, akkaActor, akkaStream)
+  val pekkoDependencies = Seq(pekkoHttp, pekkoActor, pekkoStream)
   val miscDependencies = Seq(playJson, jodaConvert)
   val testDependencies = Seq(scalatest)
 
-  val allDependencies = akkaDependencies ++ miscDependencies ++ testDependencies
+  val allDependencies = pekkoDependencies ++ miscDependencies ++ testDependencies
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1,5 +1,5 @@
-import sbt.Keys._
-import sbt._
+import sbt.*
+import sbt.Keys.*
 
 object BuildSettings {
   val buildOrganization = "com.github.slack-scala-client"
@@ -46,10 +46,10 @@ object BuildSettings {
 }
 
 object Dependencies {
-  val pekkaVersion = "1.0.2"
+  val pekkoVersion = "1.0.2"
 
-  val pekkoActor = "org.apache.pekko" %% "pekko-actor" % pekkaVersion
-  val pekkoStream = "org.apache.pekko" %% "pekko-stream" % pekkaVersion
+  val pekkoActor = "org.apache.pekko" %% "pekko-actor" % pekkoVersion
+  val pekkoStream = "org.apache.pekko" %% "pekko-stream" % pekkoVersion
   val pekkoHttp = "org.apache.pekko" %% "pekko-http-core" % "1.0.1"
 
   val playJson = "com.typesafe.play" %% "play-json" % "2.10.5"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -1,4 +1,4 @@
-akka.http.client.parsing.max-content-length=128m
+pekko.http.client.parsing.max-content-length=128m
 api.tostrict.timeout=10
 api.retries=5
 api.maxBackoff=30

--- a/src/main/scala/slack/Main.scala
+++ b/src/main/scala/slack/Main.scala
@@ -1,5 +1,6 @@
 package slack
 
+import org.apache.pekko.actor._
 import slack.rtm.SlackRtmClient
 
 import scala.concurrent.ExecutionContextExecutor

--- a/src/main/scala/slack/Main.scala
+++ b/src/main/scala/slack/Main.scala
@@ -1,6 +1,6 @@
 package slack
 
-import akka.actor._
+import org.apache.pekko.actor._
 import slack.rtm.SlackRtmClient
 
 import scala.concurrent.ExecutionContextExecutor

--- a/src/main/scala/slack/Main.scala
+++ b/src/main/scala/slack/Main.scala
@@ -1,6 +1,5 @@
 package slack
 
-import org.apache.pekko.actor._
 import slack.rtm.SlackRtmClient
 
 import scala.concurrent.ExecutionContextExecutor

--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -2,8 +2,8 @@ package slack.api
 
 import java.io.File
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model.Uri
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri
 import play.api.libs.json._
 import slack.api.SlackApiClient.defaultSlackApiBaseUri
 import slack.models._

--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -1,10 +1,13 @@
 package slack.api
 
+import java.io.File
+
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model.Uri
 import play.api.libs.json._
 import slack.api.SlackApiClient.defaultSlackApiBaseUri
 import slack.models._
 
-import java.io.File
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 

--- a/src/main/scala/slack/api/BlockingSlackApiClient.scala
+++ b/src/main/scala/slack/api/BlockingSlackApiClient.scala
@@ -1,13 +1,10 @@
 package slack.api
 
-import java.io.File
-
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.model.Uri
 import play.api.libs.json._
 import slack.api.SlackApiClient.defaultSlackApiBaseUri
 import slack.models._
 
+import java.io.File
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
 

--- a/src/main/scala/slack/api/RetryAfter.scala
+++ b/src/main/scala/slack/api/RetryAfter.scala
@@ -1,8 +1,5 @@
 package slack.api
 
-import org.apache.pekko.http.scaladsl.model.HttpResponse
-
-import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration._
 import scala.util.Try
 

--- a/src/main/scala/slack/api/RetryAfter.scala
+++ b/src/main/scala/slack/api/RetryAfter.scala
@@ -1,5 +1,8 @@
 package slack.api
 
+import org.apache.pekko.http.scaladsl.model.HttpResponse
+
+import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration._
 import scala.util.Try
 

--- a/src/main/scala/slack/api/RetryAfter.scala
+++ b/src/main/scala/slack/api/RetryAfter.scala
@@ -1,6 +1,6 @@
 package slack.api
 
-import akka.http.scaladsl.model.HttpResponse
+import org.apache.pekko.http.scaladsl.model.HttpResponse
 
 import scala.compat.java8.OptionConverters._
 import scala.concurrent.duration._

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -1,20 +1,13 @@
 package slack.api
 
-import java.io.File
-import java.net.InetSocketAddress
-import org.apache.pekko.actor.ActorSystem
-import org.apache.pekko.http.scaladsl.model._
-import org.apache.pekko.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
-import org.apache.pekko.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
-import org.apache.pekko.http.scaladsl.{ClientTransport, Http}
-import org.apache.pekko.stream.RestartSettings
-import org.apache.pekko.stream.scaladsl.{RestartSource, Sink, Source}
 import com.typesafe.config.ConfigFactory
 import play.api.libs.json._
 import slack.models._
 
-import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import java.io.File
+import java.net.InetSocketAddress
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
 
 object SlackApiClient {
 

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -2,13 +2,13 @@ package slack.api
 
 import java.io.File
 import java.net.InetSocketAddress
-import akka.actor.ActorSystem
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
-import akka.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
-import akka.http.scaladsl.{ClientTransport, Http}
-import akka.stream.RestartSettings
-import akka.stream.scaladsl.{RestartSource, Sink, Source}
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import org.apache.pekko.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
+import org.apache.pekko.http.scaladsl.{ClientTransport, Http}
+import org.apache.pekko.stream.RestartSettings
+import org.apache.pekko.stream.scaladsl.{RestartSource, Sink, Source}
 import com.typesafe.config.ConfigFactory
 import play.api.libs.json._
 import slack.models._
@@ -1346,7 +1346,7 @@ class SlackApiClient private (token: String, slackApiBaseUri: Uri) {
               case Right(jsValue) =>
                 Future.successful(jsValue)
               case Left(retryAfter) =>
-                akka.pattern
+                org.apache.pekko.pattern
                   .after(retryAfter.finiteDuration, system.scheduler) {
                     Future.failed(retryAfter.invalidResponseError)
                   }

--- a/src/main/scala/slack/api/SlackApiClient.scala
+++ b/src/main/scala/slack/api/SlackApiClient.scala
@@ -1,13 +1,20 @@
 package slack.api
 
+import java.io.File
+import java.net.InetSocketAddress
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
+import org.apache.pekko.http.scaladsl.settings.{ClientConnectionSettings, ConnectionPoolSettings}
+import org.apache.pekko.http.scaladsl.{ClientTransport, Http}
+import org.apache.pekko.stream.RestartSettings
+import org.apache.pekko.stream.scaladsl.{RestartSource, Sink, Source}
 import com.typesafe.config.ConfigFactory
 import play.api.libs.json._
 import slack.models._
 
-import java.io.File
-import java.net.InetSocketAddress
-import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor, Future}
+import scala.concurrent.duration._
 
 object SlackApiClient {
 

--- a/src/main/scala/slack/rtm/SimpleEventHandlers.scala
+++ b/src/main/scala/slack/rtm/SimpleEventHandlers.scala
@@ -1,6 +1,7 @@
 package slack.rtm
 
 import slack.models._
+import org.apache.pekko.actor._
 
 private[rtm] object EventHandlerActor {
   def apply(f: (SlackEvent) => Unit)(implicit arf: ActorRefFactory): ActorRef = {

--- a/src/main/scala/slack/rtm/SimpleEventHandlers.scala
+++ b/src/main/scala/slack/rtm/SimpleEventHandlers.scala
@@ -1,7 +1,6 @@
 package slack.rtm
 
 import slack.models._
-import org.apache.pekko.actor._
 
 private[rtm] object EventHandlerActor {
   def apply(f: (SlackEvent) => Unit)(implicit arf: ActorRefFactory): ActorRef = {

--- a/src/main/scala/slack/rtm/SimpleEventHandlers.scala
+++ b/src/main/scala/slack/rtm/SimpleEventHandlers.scala
@@ -1,7 +1,7 @@
 package slack.rtm
 
 import slack.models._
-import akka.actor._
+import org.apache.pekko.actor._
 
 private[rtm] object EventHandlerActor {
   def apply(f: (SlackEvent) => Unit)(implicit arf: ActorRefFactory): ActorRef = {

--- a/src/main/scala/slack/rtm/SlackRtmClient.scala
+++ b/src/main/scala/slack/rtm/SlackRtmClient.scala
@@ -1,5 +1,10 @@
 package slack.rtm
 
+import org.apache.pekko.actor._
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.ws.TextMessage
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.util.Timeout
 import play.api.libs.json._
 import slack.api._
 import slack.models._
@@ -8,8 +13,8 @@ import slack.rtm.WebSocketClientActor._
 
 import java.util.concurrent.atomic.AtomicLong
 import scala.collection.mutable.{Set => MSet}
-import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
 
 object SlackRtmClient {

--- a/src/main/scala/slack/rtm/SlackRtmClient.scala
+++ b/src/main/scala/slack/rtm/SlackRtmClient.scala
@@ -1,10 +1,5 @@
 package slack.rtm
 
-import org.apache.pekko.actor._
-import org.apache.pekko.http.scaladsl.model.Uri
-import org.apache.pekko.http.scaladsl.model.ws.TextMessage
-import org.apache.pekko.pattern.ask
-import org.apache.pekko.util.Timeout
 import play.api.libs.json._
 import slack.api._
 import slack.models._
@@ -13,8 +8,8 @@ import slack.rtm.WebSocketClientActor._
 
 import java.util.concurrent.atomic.AtomicLong
 import scala.collection.mutable.{Set => MSet}
-import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.util.{Failure, Success, Try}
 
 object SlackRtmClient {

--- a/src/main/scala/slack/rtm/SlackRtmClient.scala
+++ b/src/main/scala/slack/rtm/SlackRtmClient.scala
@@ -1,10 +1,10 @@
 package slack.rtm
 
-import akka.actor._
-import akka.http.scaladsl.model.Uri
-import akka.http.scaladsl.model.ws.TextMessage
-import akka.pattern.ask
-import akka.util.Timeout
+import org.apache.pekko.actor._
+import org.apache.pekko.http.scaladsl.model.Uri
+import org.apache.pekko.http.scaladsl.model.ws.TextMessage
+import org.apache.pekko.pattern.ask
+import org.apache.pekko.util.Timeout
 import play.api.libs.json._
 import slack.api._
 import slack.models._

--- a/src/main/scala/slack/rtm/WebSocketClientActor.scala
+++ b/src/main/scala/slack/rtm/WebSocketClientActor.scala
@@ -1,13 +1,5 @@
 package slack.rtm
 
-import org.apache.pekko.Done
-import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, ActorSystem, Props}
-import org.apache.pekko.http.scaladsl.model._
-import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
-import org.apache.pekko.http.scaladsl.settings.ClientConnectionSettings
-import org.apache.pekko.http.scaladsl.{ClientTransport, Http}
-import org.apache.pekko.stream.OverflowStrategy
-import org.apache.pekko.stream.scaladsl._
 import com.typesafe.config.ConfigFactory
 import slack.rtm.WebSocketClientActor._
 

--- a/src/main/scala/slack/rtm/WebSocketClientActor.scala
+++ b/src/main/scala/slack/rtm/WebSocketClientActor.scala
@@ -1,5 +1,13 @@
 package slack.rtm
 
+import org.apache.pekko.Done
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, ActorSystem, Props}
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
+import org.apache.pekko.http.scaladsl.settings.ClientConnectionSettings
+import org.apache.pekko.http.scaladsl.{ClientTransport, Http}
+import org.apache.pekko.stream.OverflowStrategy
+import org.apache.pekko.stream.scaladsl._
 import com.typesafe.config.ConfigFactory
 import slack.rtm.WebSocketClientActor._
 

--- a/src/main/scala/slack/rtm/WebSocketClientActor.scala
+++ b/src/main/scala/slack/rtm/WebSocketClientActor.scala
@@ -1,13 +1,13 @@
 package slack.rtm
 
-import akka.Done
-import akka.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, ActorSystem, Props}
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
-import akka.http.scaladsl.settings.ClientConnectionSettings
-import akka.http.scaladsl.{ClientTransport, Http}
-import akka.stream.OverflowStrategy
-import akka.stream.scaladsl._
+import org.apache.pekko.Done
+import org.apache.pekko.actor.{Actor, ActorLogging, ActorRef, ActorRefFactory, ActorSystem, Props}
+import org.apache.pekko.http.scaladsl.model._
+import org.apache.pekko.http.scaladsl.model.ws.{Message, TextMessage, WebSocketRequest}
+import org.apache.pekko.http.scaladsl.settings.ClientConnectionSettings
+import org.apache.pekko.http.scaladsl.{ClientTransport, Http}
+import org.apache.pekko.stream.OverflowStrategy
+import org.apache.pekko.stream.scaladsl._
 import com.typesafe.config.ConfigFactory
 import slack.rtm.WebSocketClientActor._
 

--- a/src/test/scala/slack/Credentials.scala
+++ b/src/test/scala/slack/Credentials.scala
@@ -1,5 +1,7 @@
 package slack
 
+import org.apache.pekko.actor.ActorSystem
+
 import scala.util.Try
 
 trait Credentials {

--- a/src/test/scala/slack/Credentials.scala
+++ b/src/test/scala/slack/Credentials.scala
@@ -1,6 +1,6 @@
 package slack
 
-import akka.actor.ActorSystem
+import org.apache.pekko.actor.ActorSystem
 
 import scala.util.Try
 

--- a/src/test/scala/slack/Credentials.scala
+++ b/src/test/scala/slack/Credentials.scala
@@ -1,7 +1,5 @@
 package slack
 
-import org.apache.pekko.actor.ActorSystem
-
 import scala.util.Try
 
 trait Credentials {


### PR DESCRIPTION
**What**:
- Closes #273.
- Migrates to Pekko instead of Akka

**Why**
Because of the Akka license change after 2.6.
