### PR TITLE
Two CI jobs

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -7,10 +7,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
+  build_java8_scala212:
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
@@ -19,3 +17,13 @@ jobs:
         java-version: 8
     - name: Run tests
       run: sbt test
+  build_java11_all_scala_versions:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Run tests
+      run: sbt ++test


### PR DESCRIPTION
**What**:
Defining two CI jobs to be run by Github Actions:
- one with current setup (Java 8, Scala 2.12)
- the new one with Java 11 and Scala versions

**Why**:
Because I think we have violated the Java 8 compatibility by accident by using Play 2.10. It seems to be practically:
- supporting Java 8 for Scala 2.12 builds
- requiring Java 11 for Scala 2.13+ builds
